### PR TITLE
fix: wake activity logic

### DIFF
--- a/android/src/main/java/com/doublesymmetry/trackplayer/HeadlessJsMediaService.java
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/HeadlessJsMediaService.java
@@ -96,19 +96,7 @@ public abstract class HeadlessJsMediaService extends MediaBrowserServiceCompat i
 
     @Override
     public void onCreate() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (Settings.canDrawOverlays(this)) {
-                Intent openAppIntent = getPackageManager().getLaunchIntentForPackage(getPackageName());
-                openAppIntent.setData(Uri.parse("trackplayer://service-created"));
-                openAppIntent.setAction(Intent.ACTION_VIEW);
-                openAppIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                startActivity(openAppIntent);
-            } else {
-                Timber.tag("RNTP").d("to wake RN Activity, enable draw over apps permission.");
-            }
-        }
         super.onCreate();
-
     }
     /**
      * Start a task. This method handles starting a new React instance if required.

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -80,7 +80,13 @@ class MusicService : HeadlessJsMediaService() {
                         "com.google.android.projection.gearhead"
                 )) {
             Log.d("RNTP-AA", clientPackageName + " is in the white list of waking activity.")
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Settings.canDrawOverlays(this)) {
+            val reactActivity = reactNativeHost.reactInstanceManager.currentReactContext?.currentActivity
+            if (
+                // HACK: validate reactActivity is present; if not, send wake intent
+                (reactActivity == null || reactActivity.isDestroyed)
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+                && Settings.canDrawOverlays(this)
+            ) {
                 val activityIntent = packageManager.getLaunchIntentForPackage(packageName)
                 activityIntent!!.data = Uri.parse("trackplayer://service-bound")
                 activityIntent.action = Intent.ACTION_VIEW

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -1,7 +1,6 @@
 package com.doublesymmetry.trackplayer.service
 
 import android.app.*
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ServiceInfo
@@ -12,6 +11,7 @@ import android.os.Bundle
 import android.os.IBinder
 import android.support.v4.media.RatingCompat
 import android.support.v4.media.MediaBrowserCompat.MediaItem
+import android.util.Log
 import androidx.annotation.MainThread
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.PRIORITY_LOW
@@ -71,6 +71,19 @@ class MusicService : HeadlessJsMediaService() {
             rootHints: Bundle?
     ): BrowserRoot {
         // TODO: verify clientPackageName here.
+        Log.d("RNTP-AA", clientPackageName + " attempted to get Browsable root.")
+        if (clientPackageName in arrayOf<String>(
+                        "com.android.systemui",
+                        "com.example.android.mediacontroller",
+                        "com.google.android.projection.gearhead"
+                )) {
+            Log.d("RNTP-AA", clientPackageName + " is in the white list of waking activity.")
+            val activityIntent = packageManager.getLaunchIntentForPackage(packageName)
+            activityIntent!!.data = Uri.parse("trackplayer://service-bound")
+            activityIntent.action = Intent.ACTION_VIEW
+            activityIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            startActivity(activityIntent)
+        }
         val extras = Bundle()
         extras.putInt(
             MediaConstants.DESCRIPTION_EXTRAS_KEY_CONTENT_STYLE_BROWSABLE,

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -9,6 +9,7 @@ import android.os.Binder
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
+import android.provider.Settings
 import android.support.v4.media.RatingCompat
 import android.support.v4.media.MediaBrowserCompat.MediaItem
 import android.util.Log
@@ -72,17 +73,20 @@ class MusicService : HeadlessJsMediaService() {
     ): BrowserRoot {
         // TODO: verify clientPackageName here.
         Log.d("RNTP-AA", clientPackageName + " attempted to get Browsable root.")
+
         if (clientPackageName in arrayOf<String>(
                         "com.android.systemui",
                         "com.example.android.mediacontroller",
                         "com.google.android.projection.gearhead"
                 )) {
             Log.d("RNTP-AA", clientPackageName + " is in the white list of waking activity.")
-            val activityIntent = packageManager.getLaunchIntentForPackage(packageName)
-            activityIntent!!.data = Uri.parse("trackplayer://service-bound")
-            activityIntent.action = Intent.ACTION_VIEW
-            activityIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
-            startActivity(activityIntent)
+            if (Settings.canDrawOverlays(this)) {
+                val activityIntent = packageManager.getLaunchIntentForPackage(packageName)
+                activityIntent!!.data = Uri.parse("trackplayer://service-bound")
+                activityIntent.action = Intent.ACTION_VIEW
+                activityIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                startActivity(activityIntent)
+            }
         }
         val extras = Bundle()
         extras.putInt(

--- a/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
+++ b/android/src/main/java/com/doublesymmetry/trackplayer/service/MusicService.kt
@@ -80,7 +80,7 @@ class MusicService : HeadlessJsMediaService() {
                         "com.google.android.projection.gearhead"
                 )) {
             Log.d("RNTP-AA", clientPackageName + " is in the white list of waking activity.")
-            if (Settings.canDrawOverlays(this)) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Settings.canDrawOverlays(this)) {
                 val activityIntent = packageManager.getLaunchIntentForPackage(packageName)
                 activityIntent!!.data = Uri.parse("trackplayer://service-bound")
                 activityIntent.action = Intent.ACTION_VIEW


### PR DESCRIPTION
fixes podverse/podverse-rn#1992 (comment)
restricts wake activity to within onGetRoot and only wake activity from authorized sources (UI, auto, debug controller). bluetooth is not allowed